### PR TITLE
Fixed typo in README.md file. Incorrect bundle class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ And make a `php bin/vendors install`.
   {
     return array(
       // ...
-      new Egulias\ListenersDebugCommandBundle\ListenersDebugCommandBundle(),
+      new Egulias\ListenersDebugCommandBundle\EguliasListenersDebugCommandBundle(),
       // ...
       );
   }


### PR DESCRIPTION
Fixed typo in README.md file. Bundle class should be EguliasListenersDebugCommandBundle instead of ListenersDebugCommandBundle
