### PR TITLE
Fixed crash with TableHelper when an event subscriber definition is an array of arrays

### DIFF
--- a/Command/ListenersCommand.php
+++ b/Command/ListenersCommand.php
@@ -181,10 +181,14 @@ EOF
                     if (!isset($listener['event'])) {
                         $events = $this->getEventSubscriberInformation($definition->getClass());
                         foreach ($events as $name => $event) {
+                            $priority = 0;
+                            if (is_array($event) && isset($event[1]) && is_int($event[1])) {
+                                $priority = $event[1];
+                            }
                             $listenersList[] = array(
                                 $serviceId,
                                 $name,
-                                (isset($event[1]) && !is_string($event[1])) ? $event[1] : 0,
+                                $priority,
                                 'subscriber',
                                 $definition->getClass()
                             );


### PR DESCRIPTION
Event subscriber definitions (`getSubscribedEvents()`) may be in the following format:
- `array('eventName' => 'methodName')`
- `array('eventName' => array('methodName', $priority))`
- `array('eventName' => array(array('methodName1', $priority), array('methodName2'))`

Using ListenersDebugCommand and having at least one subscriber with the last form (array of arrays), an error is raised with mbstring:

```
Warning: mb_detect_encoding() expects parameter 1 to be string, array given in /Users/lolautruche/workspace/ezsystems/ezpublish/vendor/symfony/sy
  mfony/src/Symfony/Component/Console/Helper/Helper.php line 56
```

This patch fixes that :octocat: 

Only drawback is that it doesn't show the right priority... But this would deserve some refactoring :wink: 
